### PR TITLE
use Text::ParseWords instead of naive split

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,6 +12,7 @@ my $build = Module::Build->new(
         'perl'                           => '5.008',
         'Module::Build::Pluggable::Base' => 0,
         'ExtUtils::F77'                  => 0,
+        'Text::ParseWords'               => 0,
     },
 
     test_requires => {

--- a/lib/Module/Build/Pluggable/Fortran.pm
+++ b/lib/Module/Build/Pluggable/Fortran.pm
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 our $VERSION = '0.26';
 use parent qw{Module::Build::Pluggable::Base};
+use Text::ParseWords qw(shellwords);
 
 BEGIN {
     eval "use ExtUtils::F77";
@@ -32,7 +33,7 @@ sub HOOK_configure {
     $self->build_requires( 'ExtUtils::F77'      => 0 );
     $self->build_requires( 'ExtUtils::CBuilder' => '0.23' );
 
-    my @runtime = split / /, ExtUtils::F77->runtime;
+    my @runtime = shellwords(ExtUtils::F77->runtime);
     $self->_add_extra_linker_flags( @runtime, @{ $self->_fortran_obj_files } );
 
     $self->builder->add_to_cleanup('f77_underscore');


### PR DESCRIPTION
This is required by the latest `ExtUtils::F77` (but is backwards compatible with previous versions), which needed to change in order to work better on Windows. Fixes https://github.com/PDLPorters/extutils-f77/issues/8.